### PR TITLE
Use Raster as an observation in Tracker

### DIFF
--- a/src/glimpse/camera.py
+++ b/src/glimpse/camera.py
@@ -1026,7 +1026,7 @@ class Camera:
         ntiles = len(tile_indices)
         # Initialize array
         nbands = (values.shape[2] if has_values else 0) + return_depth
-        # TODO: Use something faster that full
+        # TODO: Use something faster than full
         array = np.full((self.imgsz[1], self.imgsz[0], nbands), np.nan)
         # Define parallel process
         bar = helpers._progress_bar(max=ntiles)

--- a/src/glimpse/camera.py
+++ b/src/glimpse/camera.py
@@ -963,12 +963,12 @@ class Camera:
         Arguments:
             dem: :class:`Raster` object containing elevations.
             values: Values to use in building the image.
-                Must have the same 2-dimensional shape as `dem.Z` but can have
+                Must have the same 2-dimensional shape as `dem.array` but can have
                 multiple layers stacked along the 3rd dimension.
                 Cannot be `None` unless `return_depth` is True.
             mask: Boolean mask of cells of `dem` to include.
-                Must have the same shape as `dem.Z`.
-                If `None`, only NaN cells in `dem.Z` are skipped.
+                Must have the same shape as `dem.array`.
+                If `None`, only NaN cells in `dem.array` are skipped.
             tile_size: Target size of `dem` tiles.
             tile_overlap: Overlap between `dem` tiles.
             scale: Target `dem` cells per image pixel.
@@ -1017,7 +1017,7 @@ class Camera:
         elif not return_depth:
             raise ValueError("values cannot be missing if return_depth is False")
         if mask is None:
-            mask = ~np.isnan(dem.Z)
+            mask = ~np.isnan(dem.array)
         if mask.shape != dem.shape:
             raise ValueError("mask does not have the same 2-d shape as dem")
         parallel = helpers._parse_parallel(parallel)
@@ -1042,7 +1042,11 @@ class Camera:
             if has_values:
                 tile_values = values[ij]  # type: ignore
             # Scale tile based on distance from camera
-            mean_xyz = tile.xlim.mean(), tile.ylim.mean(), np.nanmean(tile.Z[tile_mask])
+            mean_xyz = (
+                tile.xlim.mean(),
+                tile.ylim.mean(),
+                np.nanmean(tile.array[tile_mask]),
+            )
             if np.isnan(mean_xyz[2]):
                 # No cells with elevations
                 return None
@@ -1062,7 +1066,7 @@ class Camera:
                 )
             # Project tile
             xyz = helpers.grid_to_points(
-                (tile.X[tile_mask], tile.Y[tile_mask], tile.Z[tile_mask])
+                (tile.X[tile_mask], tile.Y[tile_mask], tile.array[tile_mask])
             )
             if return_depth:
                 xy, depth = self._xyz_to_xy(xyz, return_depth=True)

--- a/src/glimpse/convert/converter.py
+++ b/src/glimpse/convert/converter.py
@@ -47,7 +47,7 @@ class Converter:
         self.xcam = xcam
         self.cam = cam
         if isinstance(uv, int):
-            uv = self._grid(n=uv)
+            uv = self._grid(uv)
         self.uv = np.atleast_2d(uv)
 
     def _grid(self, n: int) -> np.ndarray:

--- a/src/glimpse/image.py
+++ b/src/glimpse/image.py
@@ -12,6 +12,8 @@ from . import helpers
 from .camera import Camera
 from .exif import Exif
 
+Number = Union[int, float]
+
 
 class Image:
     """
@@ -268,6 +270,14 @@ class Image:
             True
         """
         self.cam.set_plot_limits()
+
+    def xyz_to_uv(self, xyz: np.ndarray, **kwargs: Any) -> np.ndarray:
+        """
+        Project world coordinates to image coordinates.
+
+        See :meth:`Camera.xyz_to_uv`.
+        """
+        return self.cam.xyz_to_uv(xyz, **kwargs)
 
     def project(self, cam: Camera, method: str = "linear") -> np.ndarray:
         """

--- a/src/glimpse/image.py
+++ b/src/glimpse/image.py
@@ -31,6 +31,7 @@ class Image:
         exif (:class:`Exif`): Image metadata.
         datetime (datetime.datetime): Image capture date and time.
         array (numpy.ndarray): Cached image content.
+        size (numpy.ndarray): Image pixel size (:attr:`Camera.imgsz`).
 
     Example:
         By default, the base camera model (:class:`Camera`) and image capture time
@@ -110,6 +111,11 @@ class Image:
         self.datetime = datetime
         self.exif = exif
         self.array = None
+
+    @property
+    def size(self) -> np.ndarray:
+        """Image size in pixels (nx, ny)."""
+        return self.cam.imgsz
 
     @property
     def _path_imgsz(self) -> Tuple[int, int]:

--- a/src/glimpse/image.py
+++ b/src/glimpse/image.py
@@ -287,6 +287,10 @@ class Image:
         """
         return self.cam.uv_to_xyz(uv, directions=directions, **kwargs)
 
+    def inbounds(self, uv: np.ndarray) -> np.ndarray:
+        """Whether image coordinates are in (or on the edges of) the image."""
+        return self.cam.inframe(uv)
+
     def project(self, cam: Camera, method: str = "linear") -> np.ndarray:
         """
         Project image into another camera.

--- a/src/glimpse/image.py
+++ b/src/glimpse/image.py
@@ -12,8 +12,6 @@ from . import helpers
 from .camera import Camera
 from .exif import Exif
 
-Number = Union[int, float]
-
 
 class Image:
     """
@@ -278,6 +276,16 @@ class Image:
         See :meth:`Camera.xyz_to_uv`.
         """
         return self.cam.xyz_to_uv(xyz, **kwargs)
+
+    def uv_to_xyz(
+        self, uv: np.ndarray, directions: bool = False, **kwargs: Any
+    ) -> np.ndarray:
+        """
+        Project world coordinates to image coordinates.
+
+        See :meth:`Camera.uv_to_xyz`. Returns absolute world coordinates by default.
+        """
+        return self.cam.uv_to_xyz(uv, directions=directions, **kwargs)
 
     def project(self, cam: Camera, method: str = "linear") -> np.ndarray:
         """

--- a/src/glimpse/raster.py
+++ b/src/glimpse/raster.py
@@ -414,6 +414,44 @@ class Grid:
             xy_box, centers=centers, edges=edges, inbounds=inbounds
         ).flatten()
 
+    def xyz_to_uv(self, xyz: np.ndarray) -> np.ndarray:
+        """
+        Convert world coordinates to image coordinates.
+
+        Arguments:
+            xyz: World coordinates (n, [x, y, z]). Dimension z is optional and unused.
+
+        Returns:
+            Image coordinates (n, [u, v]).
+
+        Examples:
+            >>> grid = Grid((3, 2), x=(0, 30), y=(4, 0))
+            >>> xyz = [(5, 3), (15, 2), (30, 0)]
+            >>> uv = grid.xyz_to_uv(xyz)
+            >>> uv
+            array([[0.5, 0.5],
+                   [1.5, 1. ],
+                   [3. , 2. ]])
+            >>> (grid.uv_to_xyz(uv)[:, 0:2] == xyz).all()
+            True
+        """
+        xyz = np.asarray(xyz)
+        return (xyz[:, 0:2] - (self.xlim[0], self.ylim[0])) / self.d
+
+    def uv_to_xyz(self, uv: np.ndarray) -> np.ndarray:
+        """
+        Convert image coordinates to world coordinates.
+
+        Arguments:
+            uv: Image coordinates (n, [u, v]).
+
+        Returns:
+            World coordinates (n, [x, y, z]). Dimension z is NaN.
+        """
+        uv = np.asarray(uv)
+        xy = uv * self.d + (self.xlim[0], self.ylim[0])
+        return np.column_stack((xy, np.full((xy.shape[0], 1), np.nan)))
+
     def rowcol_to_xy(self, rowcol: np.ndarray) -> np.ndarray:
         """
         Convert array indices to map coordinates.

--- a/src/glimpse/track/observer.py
+++ b/src/glimpse/track/observer.py
@@ -18,7 +18,6 @@ class Observer:
     A sequence of images taken from the same camera position.
 
     Attributes:
-        xyz (np.ndarray): Camera position in world coordinates.
         images (List[Image]): Images with equal camera position (xyz),
             focal length (f), image size (imgsz) and
             strictly increasing in time (datetime).
@@ -56,7 +55,6 @@ class Observer:
         if any(time_deltas <= 0):
             raise ValueError("Image datetimes are not stricly increasing")
         self.images = list(images)
-        self.xyz = images[0].cam.xyz
         self.datetimes = np.array(datetimes)
         self.sigma = sigma
         self.cache = cache

--- a/src/glimpse/track/observer.py
+++ b/src/glimpse/track/observer.py
@@ -58,8 +58,8 @@ class Observer:
         self.datetimes = np.array(datetimes)
         self.sigma = sigma
         self.cache = cache
-        n = self.images[0].cam.imgsz
-        self._grid = Grid(n=n, x=(0, n[0]), y=(0, n[1]))
+        size = self.images[0].cam.imgsz
+        self._grid = Grid(size, x=(0, size[0]), y=(0, size[1]))
 
     def index(
         self,

--- a/src/glimpse/track/tracker.py
+++ b/src/glimpse/track/tracker.py
@@ -566,7 +566,7 @@ class Tracker:
             box[:, 1] += np.hstack((-nrows, nrows)) * 0.5
         box = np.vstack((np.floor(box[0, :]), np.ceil(box[1, :]))).astype(int)
         # Check that box is within image bounds
-        if not all(self.observers[obs].grid.inbounds(box)):
+        if not all(self.observers[obs].images[img].inbounds(box)):
             warnings.warn(
                 "Particles too close to or beyond image bounds, skipping image"
             )

--- a/src/glimpse/track/tracker.py
+++ b/src/glimpse/track/tracker.py
@@ -519,7 +519,7 @@ class Tracker:
         # Compute image box centered around particle mean
         xyz = self.particle_mean[None, 0:3]
         uv = self.observers[obs].xyz_to_uv(xyz, img=img).ravel()
-        box = self.observers[obs].tile_box(uv, size=tile_size)
+        box = self.observers[obs].tile_box(uv, size=tile_size, img=img)
         # Build template
         template = {
             "obs": obs,

--- a/src/glimpse/track/tracks.py
+++ b/src/glimpse/track/tracks.py
@@ -351,7 +351,9 @@ class Tracks:
                 track_uv[-1, 0], track_uv[-1, 1], color="red", marker="."
             )[0]
             # Image: Tile
-            box = self.tracker.observers[obs].tile_box(track_uv[-1], size=img_size)
+            box = self.tracker.observers[obs].tile_box(
+                track_uv[-1], size=img_size, img=img
+            )
             tile = self.tracker.observers[obs].extract_tile(img=img, box=box)
             image_tile = self.tracker.observers[obs].plot_tile(
                 tile=tile, box=box, axes=axes[1]
@@ -463,7 +465,7 @@ class Tracks:
                 image_mean.set_data(track_uv[-1, 0], track_uv[-1, 1])
                 # Image: Tile
                 box = self.tracker.observers[obs].tile_box(
-                    uv=track_uv[-1, :], size=img_size
+                    uv=track_uv[-1, :], size=img_size, img=img
                 )
                 tile = self.tracker.observers[obs].extract_tile(box=box, img=img)
                 image_tile.set_data(tile)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -18,6 +18,7 @@ def test_initializes_with_attributes_from_file() -> None:
     np.testing.assert_allclose(
         img.cam.f, img.exif.fmm * np.divide(img.exif.imgsz, img.exif.sensorsz)
     )
+    np.testing.assert_equal(img.size, img.cam.imgsz)
 
 
 def test_initializes_with_custom_attributes() -> None:
@@ -33,6 +34,7 @@ def test_initializes_with_custom_attributes() -> None:
         img.cam.f,
         img.exif.fmm * np.divide(args["cam"]["imgsz"], args["cam"]["sensorsz"]),
     )
+    np.testing.assert_equal(img.size, args["cam"]["imgsz"])
 
 
 def test_reads_data_from_file() -> None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -12,19 +12,19 @@ import glimpse
 
 def test_initializes_default_raster() -> None:
     """Initializes Raster with default coordinate system."""
-    Z = np.zeros((3, 3))
+    Z = np.zeros((4, 3))
     dem = glimpse.Raster(Z)
     assert all(dem.xlim == (0, Z.shape[1]))
     assert all(dem.ylim == (0, Z.shape[0]))
     assert all(dem.zlim == (Z.min(), Z.max()))
-    assert all(dem.n == Z.shape)
+    assert all(dem.size == Z.shape[::-1])
     assert all(dem.d == (1, 1))
     assert all(dem.min == (0, 0))
     assert all(dem.max == Z.shape[::-1])
     assert all(dem.x == (0.5, 1.5, 2.5))
-    assert all(dem.y == (0.5, 1.5, 2.5))
-    assert (dem.X == ((dem.x, dem.x, dem.x))).all()
-    assert (dem.Y.T == ((dem.y, dem.y, dem.y))).all()
+    assert all(dem.y == (0.5, 1.5, 2.5, 3.5))
+    assert (dem.X == [dem.x] * Z.shape[0]).all()
+    assert (dem.Y.T == [dem.y] * Z.shape[1]).all()
 
 
 def test_initializes_custom_raster() -> None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -155,7 +155,7 @@ def test_writes_and_reads_raster() -> None:
     # Write to file and read
     tempfile = "temp.tif"
     old.write(tempfile)
-    new = glimpse.Raster.read(tempfile)
+    new = glimpse.Raster.open(tempfile)
     np.testing.assert_equal(old.array, new.array)
     np.testing.assert_equal(old.x, new.x)
     np.testing.assert_equal(old.y, new.y)
@@ -175,7 +175,7 @@ def test_interpolates_rasters() -> None:
         os.path.join("tests", "000nan.tif"),
         os.path.join("tests", "11-1nan.tif"),
     ]
-    means = [glimpse.Raster.read(path) for path in mean_paths]
+    means = [glimpse.Raster.open(path) for path in mean_paths]
     Zs = [mean.array for mean in means]
     sigma_paths = mean_paths
     sigmas = means

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -62,7 +62,7 @@ def test_samples_raster(tol: float = 1e-13) -> None:
     dem = glimpse.Raster(Z, (-0.5, 3.5), (-0.5, 3.5))
     # Sample cells centers along diagonal
     xy_diagonal = np.column_stack((dem.x, dem.y))
-    dz_points = dem.sample(xy_diagonal) - dem.Z.diagonal()
+    dz_points = dem.sample(xy_diagonal) - dem.array.diagonal()
     assert all(dz_points < tol)
 
 
@@ -76,39 +76,39 @@ def test_crops_raster_with_ascending_y() -> None:
     # Equal bounds
     cdem = dem.copy()
     cdem.crop(xlim=(0, 3), ylim=(0, 3))
-    assert (dem.Z == cdem.Z).all()
+    assert (dem.array == cdem.array).all()
     # Crop bounds: x left edge
     cdem = dem.copy()
     cdem.crop(xlim=(0, 2))
     assert all(cdem.xlim == (0, 2))
-    assert (cdem.Z == Z[:, 0:2]).all()
+    assert (cdem.array == Z[:, 0:2]).all()
     # Crop bounds: x right edge (w/ overshoot)
     cdem = dem.copy()
     cdem.crop(xlim=(2, 4))
     assert all(cdem.xlim == (2, 3))
-    assert (cdem.Z == Z[:, 2:3]).all()
+    assert (cdem.array == Z[:, 2:3]).all()
     # Crop bounds: y top edge
     cdem = dem.copy()
     cdem.crop(ylim=(0, 2))
     assert all(cdem.ylim == (0, 2))
-    assert (cdem.Z == Z[0:2, :]).all()
+    assert (cdem.array == Z[0:2, :]).all()
     # Crop bounds: y bottom edge (w/ overshoot)
     cdem = dem.copy()
     cdem.crop(ylim=(2, 4))
     assert all(cdem.ylim == (2, 3))
-    assert (cdem.Z == Z[2:3, :]).all()
+    assert (cdem.array == Z[2:3, :]).all()
     # Crop bounds: x, y interior
     cdem = dem.copy()
     cdem.crop(xlim=(1, 2), ylim=(1, 2))
     assert all(cdem.xlim == (1, 2))
     assert all(cdem.ylim == (1, 2))
-    assert (cdem.Z == Z[1:2, 1:2]).all()
+    assert (cdem.array == Z[1:2, 1:2]).all()
     # Crop bounds: x, y interior (non-edges)
     cdem = dem.copy()
     cdem.crop(xlim=(1.5, 1.9), ylim=(1, 1.9))
     assert all(cdem.xlim == (1, 2))
     assert all(cdem.ylim == (1, 2))
-    assert (cdem.Z == Z[1:2, 1:2]).all()
+    assert (cdem.array == Z[1:2, 1:2]).all()
 
 
 def test_crops_raster_with_descending_y() -> None:
@@ -119,13 +119,13 @@ def test_crops_raster_with_descending_y() -> None:
     cdem = dem.copy()
     cdem.crop(xlim=(0, 3), ylim=(0, 3))
     assert all(dem.xlim == cdem.xlim)
-    assert (dem.Z == cdem.Z).all()
+    assert (dem.array == cdem.array).all()
     # Crop bounds: x, y interior (non-edges)
     cdem = dem.copy()
     cdem.crop(xlim=(1.5, 1.9), ylim=(1, 1.9))
     assert all(cdem.xlim == (2, 1))
     assert all(cdem.ylim == (2, 1))
-    assert (cdem.Z == Z[1:2, 1:2]).all()
+    assert (cdem.array == Z[1:2, 1:2]).all()
 
 
 def test_resizes_raster() -> None:
@@ -147,7 +147,7 @@ def test_resizes_raster() -> None:
 def test_writes_and_reads_raster() -> None:
     """Writes Raster to file and reads it back from file."""
     old = glimpse.Raster(
-        Z=np.array([(0, 0, 0), (0, np.nan, 0), (1, 1, 1)], dtype=float),
+        np.array([(0, 0, 0), (0, np.nan, 0), (1, 1, 1)], dtype=float),
         x=np.array((1, 2, 3), dtype=float),
         y=np.array((3, 2, 1), dtype=float),
         crs="+init=epsg:4326",
@@ -156,7 +156,7 @@ def test_writes_and_reads_raster() -> None:
     tempfile = "temp.tif"
     old.write(tempfile)
     new = glimpse.Raster.read(tempfile)
-    np.testing.assert_equal(old.Z, new.Z)
+    np.testing.assert_equal(old.array, new.array)
     np.testing.assert_equal(old.x, new.x)
     np.testing.assert_equal(old.y, new.y)
     old_crs = osgeo.osr.SpatialReference()
@@ -176,7 +176,7 @@ def test_interpolates_rasters() -> None:
         os.path.join("tests", "11-1nan.tif"),
     ]
     means = [glimpse.Raster.read(path) for path in mean_paths]
-    Zs = [mean.Z for mean in means]
+    Zs = [mean.array for mean in means]
     sigma_paths = mean_paths
     sigmas = means
     # Define tests
@@ -207,7 +207,7 @@ def test_interpolates_rasters() -> None:
         xi = x[0] + (x[1] - x[0]) * scale
         imean, isigma = interpolant(xi, extrapolate=extrapolate, return_sigma=True)
         mean = Zs[0] + (Zs[1] - Zs[0]) * scale
-        np.testing.assert_equal(imean.Z, mean)
+        np.testing.assert_equal(imean.array, mean)
         if isinstance(xi, datetime.datetime):
             # Test whether Raster.datetime set when appropriate
             assert imean.datetime == xi


### PR DESCRIPTION
Previously only `Image` could be used as an observation in `Observer` and thus used by `Tracker` to track particles.
Several changes to `Image`, `Raster`, `Observer`, `Tracks`, and `Tracker` have been made in an effort to use `Raster` together with `Image` in an `Observer`. 