### PR TITLE
Update documentation and instructions for building them

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,12 @@ You can run the pre-commit hooks anytime using:
 ```bash
 pre-commit run --all-files
 ```
+
+Other useful commands are listed in the [`Makefile`](Makefile).
+For example, to build the documentation:
+
+```bash
+make docs
+# Equivalent to:
+# poetry run sphinx-build docs docs/build
+```

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,11 @@ Classes
     Tracks
     CartesianMotion
     CylindricalMotion
+    convert.Converter
+    convert.cameras.Agisoft
+    convert.cameras.Matlab
+    convert.cameras.OpenCV
+    convert.cameras.PhotoModeler
 
 Modules
 -------
@@ -29,6 +34,6 @@ Modules
     :toctree: autosummary
     :template: module.rst
 
-    optimize
-    convert
     helpers
+    optimize
+    svg


### PR DESCRIPTION
- Add `convert.Converter` and `convert.cameras.*` classes to API reference
- Add `svg` module to API reference
- Mention Makefile commands in developer instructions. To build the documentation, run:

```bash
make docs
```